### PR TITLE
feat: Add climate global goods filter

### DIFF
--- a/src/components/global-goods/EnhancedFilterBar.tsx
+++ b/src/components/global-goods/EnhancedFilterBar.tsx
@@ -22,7 +22,13 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { Search, Filter, X, Grid3X3, List, Sliders } from "lucide-react";
+import { 
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Search, Filter, X, Grid3X3, List, Sliders, Leaf } from "lucide-react";
 import { useI18n } from "@/hooks/useI18n";
 import { useEnhancedReferenceData } from "@/hooks/useEnhancedReferenceData";
 
@@ -39,6 +45,7 @@ interface EnhancedFilterBarProps {
   selectedWMOClassifications: string[];
   selectedHealthStandards: string[];
   selectedInteropStandards: string[];
+  climateHealthFilter: boolean;
   setSearchTerm: (term: string) => void;
   setSectorFilter: (sector: string) => void;
   setSortBy: (sort: string) => void;
@@ -50,6 +57,7 @@ interface EnhancedFilterBarProps {
   setSelectedWMOClassifications: (classifications: string[]) => void;
   setSelectedHealthStandards: (standards: string[]) => void;
   setSelectedInteropStandards: (standards: string[]) => void;
+  setClimateHealthFilter: (value: boolean) => void;
   onClearFilters: () => void;
   availableClassifications: {
     who: Array<{ code: string; title: string }>;
@@ -84,6 +92,7 @@ export function EnhancedFilterBar({
   selectedWMOClassifications,
   selectedHealthStandards,
   selectedInteropStandards,
+  climateHealthFilter,
   setSearchTerm,
   setSectorFilter,
   setSortBy,
@@ -95,6 +104,7 @@ export function EnhancedFilterBar({
   setSelectedWMOClassifications,
   setSelectedHealthStandards,
   setSelectedInteropStandards,
+  setClimateHealthFilter,
   onClearFilters,
   availableClassifications,
   availableStandards,
@@ -114,7 +124,7 @@ export function EnhancedFilterBar({
                           selectedSDGs.length > 0 || selectedCountries.length > 0 ||
                           selectedWHOClassifications.length > 0 || selectedDPIClassifications.length > 0 ||
                           selectedWMOClassifications.length > 0 || selectedHealthStandards.length > 0 ||
-                          selectedInteropStandards.length > 0;
+                          selectedInteropStandards.length > 0 || climateHealthFilter;
 
   const totalAdvancedFilters = selectedSDGs.length + selectedCountries.length + 
                               selectedWHOClassifications.length + selectedDPIClassifications.length +
@@ -180,6 +190,9 @@ export function EnhancedFilterBar({
         break;
       case 'sector':
         setSectorFilter('all');
+        break;
+      case 'climate':
+        setClimateHealthFilter(false);
         break;
       case 'sdg':
         if (value) setSelectedSDGs(selectedSDGs.filter(s => s !== value));
@@ -275,6 +288,36 @@ export function EnhancedFilterBar({
 
       {/* Filter Row */}
       <div className="flex flex-col sm:flex-row gap-4">
+        {/* Climate Health Filter */}
+        <div className="flex items-center space-x-2">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="flex items-center space-x-2 p-3 rounded-lg border bg-card hover:bg-accent/10 transition-colors">
+                  <Checkbox
+                    id="climate-health"
+                    checked={climateHealthFilter}
+                    onCheckedChange={(checked) => setClimateHealthFilter(checked as boolean)}
+                    className="border-primary data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+                  />
+                  <label 
+                    htmlFor="climate-health" 
+                    className="flex items-center gap-2 text-sm font-medium cursor-pointer select-none"
+                  >
+                    <Leaf className="h-4 w-4 text-primary" />
+                    {tPage("filters.climateHealth", "globalGoods")}
+                  </label>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="max-w-xs">
+                  {tPage("filters.climateHealthTooltip", "globalGoods")}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+
         {/* Sector Filter with Label */}
         <div className="space-y-2 sm:w-48">
           <Label htmlFor="sector-filter" className="text-sm font-medium">
@@ -599,6 +642,16 @@ export function EnhancedFilterBar({
               <X 
                 className="h-3 w-3 cursor-pointer" 
                 onClick={() => removeFilter('sector')}
+              />
+            </Badge>
+          )}
+          {climateHealthFilter && (
+            <Badge variant="secondary" className="flex items-center gap-1">
+              <Leaf className="h-3 w-3" />
+              {tPage("filters.climateHealth", "globalGoods")}
+              <X 
+                className="h-3 w-3 cursor-pointer" 
+                onClick={() => removeFilter('climate')}
               />
             </Badge>
           )}

--- a/src/i18n/locales/en/pages/globalGoods.json
+++ b/src/i18n/locales/en/pages/globalGoods.json
@@ -9,7 +9,9 @@
     "sectorLabel": "Filter by type",
     "allSectors": "All Global Goods Types",
     "sortLabel": "Sort by",
-    "clearFilters": "Clear filters"
+    "clearFilters": "Clear filters",
+    "climateHealth": "Climate & Health",
+    "climateHealthTooltip": "Show only global goods that support climate and health integration, including climate resilience, environmental monitoring, and sustainability features"
   },
   "noResults": {
     "title": "No global goods found",

--- a/src/i18n/locales/es/pages/globalGoods.json
+++ b/src/i18n/locales/es/pages/globalGoods.json
@@ -9,7 +9,9 @@
     "sectorLabel": "Filtrar por tipo",
     "allSectors": "Todos los Tipos de Bienes Globales",
     "sortLabel": "Ordenar por",
-    "clearFilters": "Borrar filtros"
+    "clearFilters": "Borrar filtros",
+    "climateHealth": "Clima y Salud",
+    "climateHealthTooltip": "Mostrar solo bienes globales que apoyan la integración de clima y salud, incluyendo resiliencia climática, monitoreo ambiental y características de sostenibilidad"
   },
   "noResults": {
     "title": "No se encontraron bienes globales",

--- a/src/i18n/locales/fr/pages/globalGoods.json
+++ b/src/i18n/locales/fr/pages/globalGoods.json
@@ -9,7 +9,9 @@
     "sectorLabel": "Filtrer par type",
     "allSectors": "Tous les Types de Biens Mondiaux",
     "sortLabel": "Trier par",
-    "clearFilters": "Effacer les filtres"
+    "clearFilters": "Effacer les filtres",
+    "climateHealth": "Climat et Santé",
+    "climateHealthTooltip": "Afficher uniquement les biens mondiaux qui soutiennent l'intégration climat et santé, y compris la résilience climatique, la surveillance environnementale et les caractéristiques de durabilité"
   },
   "noResults": {
     "title": "Aucun bien mondial trouvé",

--- a/src/pages/GlobalGoodsPageFlat.tsx
+++ b/src/pages/GlobalGoodsPageFlat.tsx
@@ -296,6 +296,7 @@ function CatalogContent() {
           selectedWMOClassifications={selectedWMOClassifications}
           selectedHealthStandards={selectedHealthStandards}
           selectedInteropStandards={selectedInteropStandards}
+          climateHealthFilter={climateHealthFilter}
           setSearchTerm={setSearchTerm}
           setSectorFilter={setSectorFilter}
           setSortBy={setSortBy}
@@ -307,6 +308,7 @@ function CatalogContent() {
           setSelectedWMOClassifications={setSelectedWMOClassifications}
           setSelectedHealthStandards={setSelectedHealthStandards}
           setSelectedInteropStandards={setSelectedInteropStandards}
+          setClimateHealthFilter={setClimateHealthFilter}
           onClearFilters={handleClearAllFilters}
           availableClassifications={availableFilterOptions.classifications}
           availableStandards={availableFilterOptions.standards}
@@ -314,23 +316,7 @@ function CatalogContent() {
         />
       </div>
 
-      {/* Active Filters Display */}
-      {climateHealthFilter && (
-        <div className="mb-6">
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">Active filters:</span>
-            <Badge variant="secondary" className="flex items-center gap-1">
-              Climate & Health
-              <button 
-                onClick={() => setClimateHealthFilter(false)}
-                className="ml-1 hover:bg-muted rounded-full p-0.5"
-              >
-                ×
-              </button>
-            </Badge>
-          </div>
-        </div>
-      )}
+      {/* Active Filters Display - Now integrated in filter bar */}
 
       {/* Results Summary */}
       <div className="bg-card rounded-lg border p-4 mb-6 shadow-sm">


### PR DESCRIPTION
Implement the plan to add a climate filter to the global goods page. This includes updating the `EnhancedFilterBar` to expose the filter, modifying `GlobalGoodsPageFlat` to pass the state, and enhancing the UI with a checkbox and active filter display. The filter will check for `ClimateHealth: true` or specific IDs, or goods with a non-empty `ClimateAndHealthIntegration.Description`. Translations for the new filter have also been added.