### PR TITLE
Fix ewars and geoprism data

### DIFF
--- a/public/data/global-goods/individual/ewars.json
+++ b/public/data/global-goods/individual/ewars.json
@@ -1,7 +1,7 @@
 {
   "ID": "ewars",
   "Name": "Early Warning and Response System for climate-senstive diseases",
-  "Logo": "",
+  "Logo": "/uploads/logo-Placeholder.jpg",
   "Website": {
     "main": {
       "url": "https://tdr.who.int/activities/ewars-csd",

--- a/public/data/global-goods/individual/geoprism.json
+++ b/public/data/global-goods/individual/geoprism.json
@@ -1,7 +1,7 @@
 {
     "ID": "geoprism",
     "Name": "GeoPrism Registry",
-    "Logo": "",
+    "Logo": "/uploads/logo-Placeholder.jpg",
     "Website": {
       "main": {
         "url": "https://geoprismregistry.com",
@@ -42,7 +42,7 @@
       ],
       "WMO": [
         "WMO_C3",
-        "WMO-B1"
+        "WMO_B1"
       ],
       "DPI": [
         "DPI_B5"


### PR DESCRIPTION
Update ewars.json and geoprism.json to use placeholder logos. Correct the WMO-B1 classification in geoprism.json to WMO_B1. The license field is confirmed to be a string reference key and does not require changes.